### PR TITLE
Add Jefferson and Cambria Co. to PA10 D8

### DIFF
--- a/congressional-counties-parties.csv
+++ b/congressional-counties-parties.csv
@@ -3453,7 +3453,9 @@ meae.congressional.congress10.pa.county,pas_york,42133,6,1271,1,NA,NA,NA,NA,NA,N
 meae.congressional.congress10.pa.county,pas_bedford,42009,7,51,0.049,NA,NA,495,0.472,NA,NA,NA,NA,503,0.48,NA,NA,county
 meae.congressional.congress10.pa.county,pas_franklin,42055,7,801,0.441,NA,NA,1016,0.559,NA,NA,NA,NA,NA,NA,NA,NA,county
 meae.congressional.congress10.pa.county,pas_armstrong,42005,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
+meae.congressional.congress10.pa.county,pas_cambria,42021,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
 meae.congressional.congress10.pa.county,pas_indiana,42063,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
+meae.congressional.congress10.pa.county,pas_jefferson,42065,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
 meae.congressional.congress10.pa.county,pas_somerset,42111,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
 meae.congressional.congress10.pa.county,pas_westmoreland,42129,8,NA,NA,NA,NA,NA,1,NA,NA,NA,NA,NA,NA,NA,NA,district
 meae.congressional.congress10.pa.county,pas_fayette,42051,9,NA,NA,NA,NA,1422,1,NA,NA,NA,NA,NA,NA,NA,NA,county


### PR DESCRIPTION
Jefferson and Cambria Co. are not listed under NNV as parts of D8 for Congress 10, but they are for Congress 9 and 11. I assumed that both counties are under D8 for Congress 10.

PA09: https://elections.lib.tufts.edu/catalog/tufts:pa.uscongress8.1804
PA10: https://elections.lib.tufts.edu/catalog/tufts:pa.uscongress8.1806
PA11: https://elections.lib.tufts.edu/catalog/tufts:pa.uscongress8.1808

close #98 